### PR TITLE
Android riscv64 support

### DIFF
--- a/llvm/Android.bp
+++ b/llvm/Android.bp
@@ -260,6 +260,14 @@ llvm_aarch64_static_libraries = [
     "libLLVM15AArch64Disassembler",
 ]
 
+llvm_riscv_static_libraries = [
+    "libLLVM15RISCVCodeGen",
+    "libLLVM15RISCVInfo",
+    "libLLVM15RISCVDesc",
+    "libLLVM15RISCVAsmParser",
+    "libLLVM15RISCVDisassembler",
+]
+
 llvm_amdgpu_static_libraries = [
     "libLLVM15AMDGPUCodeGen",
     "libLLVM15AMDGPUInfo",
@@ -393,6 +401,9 @@ cc_library_shared {
         android_arm64: {
             whole_static_libs: llvm_aarch64_static_libraries +
                 llvm_arm_static_libraries,
+        },
+        android_riscv64: {
+            whole_static_libs: llvm_riscv_static_libraries,
         },
     },
 }

--- a/llvm/device/include/llvm/Config/AsmParsers.def
+++ b/llvm/device/include/llvm/Config/AsmParsers.def
@@ -31,10 +31,6 @@
 #elif defined(__i386__) || defined(__x86_64__)
   LLVM_ASM_PARSER(X86)
 
-#if defined(FORCE_BUILD_AMDGPU)
-  LLVM_ASM_PARSER(AMDGPU)
-#endif
-
 #if defined(FORCE_BUILD_ARM)
   LLVM_ASM_PARSER(ARM)
   LLVM_ASM_PARSER(AArch64)
@@ -47,6 +43,10 @@
   LLVM_ASM_PARSER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_ASM_PARSER
+#endif
+
+#if defined(FORCE_BUILD_AMDGPU)
+  LLVM_ASM_PARSER(AMDGPU)
 #endif
 
 #undef LLVM_ASM_PARSER

--- a/llvm/device/include/llvm/Config/AsmParsers.def
+++ b/llvm/device/include/llvm/Config/AsmParsers.def
@@ -43,6 +43,8 @@
 #elif defined(__aarch64__)
   LLVM_ASM_PARSER(ARM)
   LLVM_ASM_PARSER(AArch64)
+#elif defined(__riscv)
+  LLVM_ASM_PARSER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_ASM_PARSER
 #endif

--- a/llvm/device/include/llvm/Config/AsmPrinters.def
+++ b/llvm/device/include/llvm/Config/AsmPrinters.def
@@ -43,6 +43,8 @@
 #elif defined(__aarch64__)
   LLVM_ASM_PRINTER(ARM)
   LLVM_ASM_PRINTER(AArch64)
+#elif defined(__riscv)
+  LLVM_ASM_PRINTER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_ASM_PRINTER
 #endif

--- a/llvm/device/include/llvm/Config/AsmPrinters.def
+++ b/llvm/device/include/llvm/Config/AsmPrinters.def
@@ -31,10 +31,6 @@
 #elif defined(__i386__) || defined(__x86_64__)
   LLVM_ASM_PRINTER(X86)
 
-#if defined(FORCE_BUILD_AMDGPU)
-  LLVM_ASM_PRINTER(AMDGPU)
-#endif
-
 #if defined(FORCE_BUILD_ARM)
   LLVM_ASM_PRINTER(ARM)
   LLVM_ASM_PRINTER(AArch64)
@@ -47,6 +43,10 @@
   LLVM_ASM_PRINTER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_ASM_PRINTER
+#endif
+
+#if defined(FORCE_BUILD_AMDGPU)
+  LLVM_ASM_PRINTER(AMDGPU)
 #endif
 
 #undef LLVM_ASM_PRINTER

--- a/llvm/device/include/llvm/Config/Disassemblers.def
+++ b/llvm/device/include/llvm/Config/Disassemblers.def
@@ -43,6 +43,8 @@
 #elif defined(__aarch64__)
   LLVM_DISASSEMBLER(ARM)
   LLVM_DISASSEMBLER(AArch64)
+#elif defined(__riscv)
+  LLVM_DISASSEMBLER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_DISASSEMBLER
 #endif

--- a/llvm/device/include/llvm/Config/Disassemblers.def
+++ b/llvm/device/include/llvm/Config/Disassemblers.def
@@ -31,10 +31,6 @@
 #elif defined(__i386__) || defined(__x86_64__)
   LLVM_DISASSEMBLER(X86)
 
-#if defined(FORCE_BUILD_AMDGPU)
-  LLVM_DISASSEMBLER(AMDGPU)
-#endif
-
 #if defined(FORCE_BUILD_ARM)
   LLVM_DISASSEMBLER(ARM)
   LLVM_DISASSEMBLER(AArch64)
@@ -47,6 +43,10 @@
   LLVM_DISASSEMBLER(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_DISASSEMBLER
+#endif
+
+#if defined(FORCE_BUILD_AMDGPU)
+  LLVM_DISASSEMBLER(AMDGPU)
 #endif
 
 #undef LLVM_DISASSEMBLER

--- a/llvm/device/include/llvm/Config/TargetMCAs.def
+++ b/llvm/device/include/llvm/Config/TargetMCAs.def
@@ -31,10 +31,6 @@
 #elif defined(__i386__) || defined(__x86_64__)
   LLVM_TARGETMCA(X86)
 
-#if defined(FORCE_BUILD_AMDGPU)
-  LLVM_TARGETMCA(AMDGPU)
-#endif
-
 #if defined(FORCE_BUILD_ARM)
   LLVM_TARGETMCA(ARM)
   LLVM_TARGETMCA(AArch64)
@@ -47,6 +43,10 @@
   LLVM_TARGETMCA(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_TARGETMCA
+#endif
+
+#if defined(FORCE_BUILD_AMDGPU)
+  LLVM_TARGETMCA(AMDGPU)
 #endif
 
 #undef LLVM_TARGETMCA

--- a/llvm/device/include/llvm/Config/TargetMCAs.def
+++ b/llvm/device/include/llvm/Config/TargetMCAs.def
@@ -43,6 +43,8 @@
 #elif defined(__aarch64__)
   LLVM_TARGETMCA(ARM)
   LLVM_TARGETMCA(AArch64)
+#elif defined(__riscv)
+  LLVM_TARGETMCA(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_TARGETMCA
 #endif

--- a/llvm/device/include/llvm/Config/Targets.def
+++ b/llvm/device/include/llvm/Config/Targets.def
@@ -42,6 +42,8 @@
 #elif defined(__aarch64__)
   LLVM_TARGET(ARM)
   LLVM_TARGET(AArch64)
+#elif defined(__riscv)
+  LLVM_TARGET(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_TARGET
 #endif

--- a/llvm/device/include/llvm/Config/Targets.def
+++ b/llvm/device/include/llvm/Config/Targets.def
@@ -30,10 +30,6 @@
 #elif defined(__i386__) || defined(__x86_64__)
   LLVM_TARGET(X86)
 
-#if defined(FORCE_BUILD_AMDGPU)
-  LLVM_TARGET(AMDGPU)
-#endif
-
 #if defined(FORCE_BUILD_ARM)
   LLVM_TARGET(ARM)
   LLVM_TARGET(AArch64)
@@ -46,6 +42,10 @@
   LLVM_TARGET(RISCV)
 #else
 #  error Unsupported TARGET_ARCH for LLVM_TARGET
+#endif
+
+#if defined(FORCE_BUILD_AMDGPU)
+  LLVM_TARGET(AMDGPU)
 #endif
 
 #undef LLVM_TARGET

--- a/llvm/include/llvm/Config/llvm-platform-config.h
+++ b/llvm/include/llvm/Config/llvm-platform-config.h
@@ -115,6 +115,32 @@
 /* LLVM name for the native target MC init function, if available */
 #define LLVM_NATIVE_TARGETMC LLVMInitializeAArch64TargetMC
 
+#elif defined(__riscv)
+
+/* LLVM architecture name for the native architecture, if available */
+#define LLVM_NATIVE_ARCH RISCV
+
+/* Host triple LLVM will be executed on */
+#define LLVM_HOST_TRIPLE "riscv64-none-linux-gnu"
+
+/* LLVM name for the native AsmParser init function, if available */
+#define LLVM_NATIVE_ASMPARSER LLVMInitializeRISCVAsmParser
+
+/* LLVM name for the native AsmPrinter init function, if available */
+#define LLVM_NATIVE_ASMPRINTER LLVMInitializeRISCVAsmPrinter
+
+/* LLVM name for the native Disassembler init function, if available */
+#define LLVM_NATIVE_DISASSEMBLER LLVMInitializeRISCVDisassembler
+
+/* LLVM name for the native Target init function, if available */
+#define LLVM_NATIVE_TARGET LLVMInitializeRISCVTarget
+
+/* LLVM name for the native TargetInfo init function, if available */
+#define LLVM_NATIVE_TARGETINFO LLVMInitializeRISCVTargetInfo
+
+/* LLVM name for the native target MC init function, if available */
+#define LLVM_NATIVE_TARGETMC LLVMInitializeRISCVTargetMC
+
 #else
 
 #error "Unknown native architecture"

--- a/llvm/lib/Target/RISCV/Android.bp
+++ b/llvm/lib/Target/RISCV/Android.bp
@@ -1,0 +1,48 @@
+cc_library_static {
+    name: "libLLVM15RISCVCodeGen",
+    defaults: [
+        "llvm15-lib-defaults",
+        "llvm15-riscv-defaults",
+    ],
+    srcs: ["*.cpp"],
+}
+
+cc_defaults {
+    name: "llvm15-riscv-defaults",
+    generated_headers: ["llvm15-gen-riscv"],
+    static_libs: ["llvm15-riscv-headers"],
+}
+
+cc_library_static {
+    name: "llvm15-riscv-headers",
+    vendor_available: true,
+    host_supported: true,
+    target: {
+        windows: {
+            enabled: true,
+        },
+    },
+    export_include_dirs: ["."],
+}
+
+llvm15_tblgen {
+    name: "llvm15-gen-riscv",
+    in: "RISCV.td",
+    outs: [
+        "RISCVGenAsmMatcher.inc",
+        "RISCVGenAsmWriter.inc",
+        "RISCVGenCompressInstEmitter.inc",
+        "RISCVGenDAGISel.inc",
+        "RISCVGenDisassemblerTables.inc",
+        "RISCVGenGlobalISel.inc",
+        "RISCVGenInstrInfo.inc",
+        "RISCVGenMCCodeEmitter.inc",
+        "RISCVGenMCPseudoLowering.inc",
+        "RISCVGenRegisterBank.inc",
+        "RISCVGenRegisterInfo.inc",
+        "RISCVGenSearchableTables.inc",
+        "RISCVGenSubtargetInfo.inc",
+    ],
+}
+
+subdirs = ["*"]

--- a/llvm/lib/Target/RISCV/AsmParser/Android.bp
+++ b/llvm/lib/Target/RISCV/AsmParser/Android.bp
@@ -1,0 +1,8 @@
+cc_library_static {
+    name: "libLLVM15RISCVAsmParser",
+    defaults: [
+        "llvm15-lib-defaults",
+        "llvm15-riscv-defaults",
+    ],
+    srcs: ["*.cpp"],
+}

--- a/llvm/lib/Target/RISCV/Disassembler/Android.bp
+++ b/llvm/lib/Target/RISCV/Disassembler/Android.bp
@@ -1,0 +1,8 @@
+cc_library_static {
+    name: "libLLVM15RISCVDisassembler",
+    defaults: [
+        "llvm15-lib-defaults",
+        "llvm15-riscv-defaults",
+    ],
+    srcs: ["*.cpp"],
+}

--- a/llvm/lib/Target/RISCV/MCTargetDesc/Android.bp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/Android.bp
@@ -1,0 +1,8 @@
+cc_library_static {
+    name: "libLLVM15RISCVDesc",
+    defaults: [
+        "llvm15-lib-defaults",
+        "llvm15-riscv-defaults",
+    ],
+    srcs: ["*.cpp"],
+}

--- a/llvm/lib/Target/RISCV/TargetInfo/Android.bp
+++ b/llvm/lib/Target/RISCV/TargetInfo/Android.bp
@@ -1,0 +1,8 @@
+cc_library_static {
+    name: "libLLVM15RISCVInfo",
+    defaults: [
+        "llvm15-lib-defaults",
+        "llvm15-riscv-defaults",
+    ],
+    srcs: ["*.cpp"],
+}

--- a/llvm/soong/tblgen.go
+++ b/llvm/soong/tblgen.go
@@ -159,6 +159,8 @@ func outToGenerator(ctx android.ModuleContext, out string) string {
 		return "-gen-x86-EVEX2VEX-tables"
 	case strings.HasSuffix(out, "X86GenMnemonicTables.inc"):
 		return "-gen-x86-mnemonic-tables -asmwriternum=1"
+	case strings.HasSuffix(out, "CompressInstEmitter.inc"):
+		return "-gen-compress-inst-emitter"
 	case out == "Attributes.inc", out == "AttributesCompatFunc.inc":
 		return "-gen-attrs"
 	case out == "IntrinsicEnums.inc":


### PR DESCRIPTION
These changes allow building LLVM, including AMDGPU, for a riscv64 board.